### PR TITLE
Fix for Issue #5: "German translation missing"

### DIFF
--- a/src/components/AdvancedSettings.jsx
+++ b/src/components/AdvancedSettings.jsx
@@ -20,7 +20,7 @@ const AdvancedSettings = () => {
         <span className="inline-block mr-2" title="Savings Mode lets you plan how much to save and for how many months. The app will optimize the allocation.">
           <svg xmlns="http://www.w3.org/2000/svg" className="inline w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><circle cx="12" cy="12" r="10" strokeWidth="2"/><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 16v-4m0-4h.01" /></svg>
         </span>
-        Enter your planned monthly savings and the number of months you want to save for.
+        {t('plannedSavingsPlanPrompt')}
       </div>
       
       <div className="flex flex-col md:flex-row gap-6 w-full">

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -10,7 +10,7 @@
   "results": "Rebalancing-Ergebnisse",
   "footer": "Portfolio Balancer - Tool für Investment-Management",
   "savingsSettings": "Spar-Einstellungen",
-  "plannedSavingsPlanPrompt": "Geben Sie Ihre gepanten monatlichen Ersparnisse und die Anzahl der Monate ein, für die Sie sparen wollen.",
+  "plannedSavingsPlanPrompt": "Geben Sie Ihre geplanten monatlichen Ersparnisse und die Anzahl der Monate ein, für die Sie sparen wollen.",
   "monthlySavings": "Monatlicher Sparbetrag",
   "rebalanceFrequency": "Rebalancing-Häufigkeit",
   "monthly": "Monatlich",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -10,6 +10,7 @@
   "results": "Rebalancing-Ergebnisse",
   "footer": "Portfolio Balancer - Tool für Investment-Management",
   "savingsSettings": "Spar-Einstellungen",
+  "plannedSavingsPlanPrompt": "Geben Sie Ihre gepanten monatlichen Ersparnisse und die Anzahl der Monate ein, für die Sie sparen wollen.",
   "monthlySavings": "Monatlicher Sparbetrag",
   "rebalanceFrequency": "Rebalancing-Häufigkeit",
   "monthly": "Monatlich",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -10,6 +10,7 @@
   "results": "Rebalancing Results",
   "footer": "Portfolio Balancer - Tool for Investment Management",
   "savingsSettings": "Savings Settings",
+  "plannedSavingsPlanPrompt": "Enter your planned monthly savings and the number of months you want to save for.",
   "monthlySavings": "Monthly Savings Amount",
   "rebalanceFrequency": "Rebalancing Frequency",
   "monthly": "Monthly",


### PR DESCRIPTION
added a language tag: 'plannedSavingsPlanPrompt' to both language files 
added a german translation for: 'Enter your planned monthly savings and the number of months you want to save for.'